### PR TITLE
Add `go mod tidy` to test commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 run-unit-tests:
+	go mod tidy && \
 	go test -v -race -timeout 30s ./...
 run-integration-tests:
-	cd tests/integration && go test -tags integration -v -race -timeout 30s ./... -run TestMain
+	cd tests/integration && \
+	go mod tidy && \
+	go test -tags integration -v -race -timeout 30s ./... -run TestMain


### PR DESCRIPTION
Ensure dependencies are up-to-date before running unit and integration tests to avoid potential issues caused by outdated or missing dependencies.