### PR TITLE
Fix `math` package

### DIFF
--- a/tests/integration/utils/utils.go
+++ b/tests/integration/utils/utils.go
@@ -1,11 +1,11 @@
 package utils
 
 import (
-	"math/rand/v2"
+	"math/rand"
 	"time"
 )
 
 // RandomDuration will return a random duration between min and max
 func RandomDuration(min, max int, unit time.Duration) time.Duration {
-	return time.Duration(rand.IntN(max-min)+min) * unit
+	return time.Duration(rand.Intn(max-min)+min) * unit
 }


### PR DESCRIPTION
The rand package import was updated from "math/rand/v2" to "math/rand" to align with the correct package version. Additionally, the method `IntN` was changed to `Intn` to match the method name in the standard library